### PR TITLE
Updated isAccelerator to handle all supported keys and modifiers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,8 @@ build/Release
 node_modules
 jspm_packages
 
+package-lock.json
+
 # Optional npm cache directory
 .npm
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # electron-is-accelerator
 
-Check if a string is a valid [Electron accelerator](https://github.com/electron/electron/blob/master/docs/api/accelerator.md) and return a boolean. This module can be used to validate user defined accelerators before using them with [MenuItems](http://electron.atom.io/docs/api/menu-item/).
+Check if a string is a valid [Electron accelerator](https://www.electronjs.org/docs/latest/tutorial/keyboard-shortcuts) and return a boolean. This module can be used to validate user defined accelerators before using them with [MenuItems](http://electron.atom.io/docs/api/menu-item/).
 
 ## Installation
 

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 "use strict";
 
-const modifiers = /^(Command|Cmd|Control|Ctrl|CommandOrControl|CmdOrCtrl|Alt|Option|AltGr|Shift|Super)$/;
-const keyCodes = /^([0-9A-Z)!@#$%^&*(:+<_>?~{|}";=,\-./`[\\\]']|F1*[1-9]|F10|F2[0-4]|Plus|Space|Tab|Backspace|Delete|Insert|Return|Enter|Up|Down|Left|Right|Home|End|PageUp|PageDown|Escape|Esc|VolumeUp|VolumeDown|VolumeMute|MediaNextTrack|MediaPreviousTrack|MediaStop|MediaPlayPause|PrintScreen)$/;
+const modifiers = /^(Command|Cmd|Control|Ctrl|CommandOrControl|CmdOrCtrl|Alt|Option|AltGr|Shift|Super|Meta)$/;
+const keyCodes = /^([0-9A-Z)!@#$%^&*(:+<_>?~{|}";=,\-./`[\\\]']|F1*[1-9]|F10|F2[0-4]|Plus|Space|Tab|Capslock|Numlock|Scrolllock|Backspace|Delete|Insert|Return|Enter|Up|Down|Left|Right|Home|End|PageUp|PageDown|Escape|Esc|VolumeUp|VolumeDown|VolumeMute|MediaNextTrack|MediaPreviousTrack|MediaStop|MediaPlayPause|PrintScreen|num[0-9]|numdec|numadd|numsub|nummult|numdiv)$/;
 
 module.exports = function (str) {
 	let parts = str.split("+");

--- a/test.js
+++ b/test.js
@@ -9,7 +9,8 @@ const keys = [
     'G',
     'Z',
     'F1',
-    'F5',
+    'F10',
+    'F11',
     'F24',
     '~',
     '!',
@@ -40,7 +41,14 @@ const keys = [
     'MediaPreviousTrack',
     'MediaStop',
     'MediaPlayPause',
-    'PrintScreen'
+    'PrintScreen',
+    'PrintScreen',
+    'Capslock',
+    'Numlock',
+    'num0',
+    'num9',
+    'numadd',
+    'nummult'
 ];
 
 const modifiers = [
@@ -54,7 +62,8 @@ const modifiers = [
     'Option',
     'AltGr',
     'Shift',
-    'Super'
+    'Super',
+    'Meta'
 ];
 
 test('multiple modifier', t => t.true(isAccelerator('CommandOrControl+Shift+Z')));
@@ -62,6 +71,8 @@ test('multiple keys', t => t.false(isAccelerator('A+Z')));
 test('typos', t => t.false(isAccelerator('CommandOrContol+A')));
 test('modifiers without keys', t => t.false(isAccelerator('CmdOrCtrl')));
 test('multiple modifiers without keys', t => t.false(isAccelerator('CmdOrCtrl+Ctrl')));
+test('capitalized numkeys', t=> t.false(isAccelerator('Num0')))
+test('capitalized numpad', t=> t.false(isAccelerator('Numdiv')))
 test('empty string', t => t.false(isAccelerator('')));
 
 // tests to check each modifiers


### PR DESCRIPTION
I found this tool very helpful until I realized it just hasn't been updated in a few years and is missing some support for newer accelerator modifiers/keys.

Thanks for putting this together, and I hope this addition helps!

Now supports numpad keys as well as scroll/num/caps lock and the meta modifier. 
Updated README to fix a broken link.
Updated tests for new modifiers/keys.